### PR TITLE
prevent exponential number of reconnect requests

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -6,6 +6,7 @@ module.exports = function(client, options) {
 	
 	var rosInstance;
 	var connected = false;
+	var connectScheduled = false;
 
 	var onFail = function() {
 		if(connected) {
@@ -13,7 +14,11 @@ module.exports = function(client, options) {
 			client.emit(constants.EVENT_DISCONNECTED);
 		}
 		connected = false;
-		setTimeout(connect, options.reconnectInterval);
+
+		if (!connectScheduled) {	
+			connectScheduled = true;
+			setTimeout(connect, options.reconnectInterval);
+		}
 	};
 
 	var onSuccess = function() {
@@ -26,6 +31,8 @@ module.exports = function(client, options) {
 	};
 	
 	var connect = function() {
+		connectScheduled = false;
+
 		rosInstance = new ROSLIB.Ros({
 			url: options.url
 		});


### PR DESCRIPTION
If connecting fails (the backend isn't running) then both the close and
error events are triggered. This results in two calls to onFail method
which schedules two retry attempts. If they fail both of them schedules
two new retires resulting in four retries. This continues until the browser is
exausted of resources (pretty fast).

This commit tracks if a connection attempt is schedules and prevent new
attempts from being schedules before the current one is finished.